### PR TITLE
ci: drop dependency to test-unit-rr

### DIFF
--- a/fluent-plugin-watch-objectspace.gemspec
+++ b/fluent-plugin-watch-objectspace.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", [">= 2.2.33"]
   spec.add_development_dependency "rake", "< 14"
-  spec.add_development_dependency "test-unit", "< 3.7"
-  spec.add_development_dependency "test-unit-rr", "< 1.1"
+  spec.add_development_dependency "test-unit"
+  spec.add_development_dependency "rr"
   spec.add_runtime_dependency "fluentd", [">= 0.14.10", "< 2"]
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,9 +1,10 @@
 $LOAD_PATH.unshift(File.expand_path("../../", __FILE__))
 require "test-unit"
-require "test/unit/rr"
+require "rr"
 require "fluent/test"
 require "fluent/test/driver/input"
 require "fluent/test/helpers"
 
 Test::Unit::TestCase.include(Fluent::Test::Helpers)
 Test::Unit::TestCase.extend(Fluent::Test::Helpers)
+Test::Unit::TestCase.include(RR::DSL)

--- a/test/plugin/test_in_watch_objectspace.rb
+++ b/test/plugin/test_in_watch_objectspace.rb
@@ -6,6 +6,10 @@ class WatchObjectspaceInputTest < Test::Unit::TestCase
     Fluent::Test.setup
   end
 
+  teardown do
+    RR.reset
+  end
+
   DEFAULT_CONFIG = config_element("ROOT", "", {})
 
   private


### PR DESCRIPTION
test-unit-rr is not compatible with test-unit 3.6.9 or later. Use rr for stub.